### PR TITLE
Syntax errors in curl command

### DIFF
--- a/index.md
+++ b/index.md
@@ -52,7 +52,7 @@ The following example shows how to call the API from a command line with curl. C
 Open a command prompt or terminal, and send a request to the API using the settings from the *parameters.json* file you created. Replace *username* and *password* with your service credentials.
 
 ```bash
-curl -X POST -u "username":"password" -d @parameters.json https://gateway.watsonplatform.net/natural-language-understanding/api/v1/analyze
+curl -X POST -u "username":"password" -d @parameters.json -H "Content-Type:application/json" https://gateway.watsonplatform.net/natural-language-understanding/api/v1/analyze?version=2017-02-27
 ```
 {: codeblock}
 


### PR DESCRIPTION
 - missing content-type header
 - missing ?version suffix

Header is required because curl cannot be relied upon to automatically detect that payload is in json format.  Version number (currently `?version=2017-02-27`) is part of the API specification and must be included .

------

Error examples:
- Existing syntax (missing header and missing version):
`curl -X POST -u "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx":"xxxxxxxxxxxx" -d @parameters.json https://gateway.watsonplatform.net/natural-language-understanding/api/v1/analyze`
```
{
  "error": "unsupported media type",
  "code": 415
}
```
- Missing version (with header included to specify json payload)
curl -X POST -u "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx":"xxxxxxxxxxxx" -d @parameters.json -H "Content-Type:application/json" https://gateway.watsonplatform.net/natural-language-understanding/api/v1/analyze`
```
{
  "error": "Missing or malformed version date parameter, e.g. version=2017-02-27.",
  "code": 400
}
```
- Working syntax (header and version specification included):
`curl -X POST -u "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx":"xxxxxxxxxxxx" -d @parameters.json -H "Content-Type:application/json" https://gateway.watsonplatform.net/natural-language-understanding/api/v1/analyze?version=2017-02-27`
```
{
  "sentiment": {
    "document": {
      "score": 0.681259,
      "label": "positive"
    }
  },
  "language": "en",
  "concepts": [
    {
      "text": "Linguistics",
      "relevance": 0.934057,
      "dbpedia_resource": "http://dbpedia.org/resource/Linguistics"
    },
    {
      "text": "Natural language processing",
      "relevance": 0.83358,
      "dbpedia_resource": "http://dbpedia.org/resource/Natural_language_processing"
    },
    {
      "text": "Programming language",
      "relevance": 0.748197,
      "dbpedia_resource": "http://dbpedia.org/resource/Programming_language"
    }
  ]
}
```
